### PR TITLE
Corrigir especificação do contador 0-7

### DIFF
--- a/level1/level2/encoder.v
+++ b/level1/level2/encoder.v
@@ -32,7 +32,7 @@ module encoder(
     assign loadn = ~numpad_pressed;
 
     encoder_dec_bcd dec_to_bcd(.decimal(numpad), .enablen(enablen), .bcd(D));
-    counter0_7 debouncer(.clk(clk), .numpad_pressed(numpad_pressed), .out(mux_d0));
+    counter0_7 debouncer(.clk(clk), .clear(numpad_pressed), .out(mux_d0));
     counterdiv100 div100(.clk(clk), .clk_out(mux_d1));
     mux2_1 mux(.selector(enablen), .d0(mux_d0), .d1(mux_d1), .out(pgt_1Hz));
 

--- a/level1/level2/encoder_test.v
+++ b/level1/level2/encoder_test.v
@@ -1,4 +1,4 @@
-`include "encoder.v"
+//`include "encoder.v"
 module encoder_test;
 reg [9:0] numpad;
 reg enable;

--- a/level1/level2/level3/counter0_7.v
+++ b/level1/level2/level3/counter0_7.v
@@ -1,6 +1,6 @@
 module counter0_7 (
     input wire clk,
-    input wire numpad_pressed,
+    input wire clear,
     output reg out
 );
 
@@ -12,13 +12,13 @@ initial begin // Valor inicial
     count <= 0;
 end
 
-always @(posedge numpad_pressed) begin // ativo quando um número do teclado é pressionado
+always @(posedge clear) begin // ativo quando um número do teclado é pressionado
     if (count == 3'd0) begin
         is_counting = 1;
     end
 end
 
-always @(negedge numpad_pressed) begin // quando o numero do teclado é solto, contagem vai até 7. 
+always @(negedge clear) begin // quando o numero do teclado é solto, contagem vai até 7. 
     if (count == 3'd7) begin
         is_counting = 0;
         count = 3'd0;
@@ -31,7 +31,7 @@ always @(posedge clk) begin
         count <= count + 1;
     end
 
-    if (count == 3'd3) begin
+    if (count == 3'd4) begin
         out <= 1;
     end
 end

--- a/level1/level2/level3/counter0_7_test.v
+++ b/level1/level2/level3/counter0_7_test.v
@@ -7,16 +7,23 @@ wire out;
 counter0_7 dut(clk, clear, out);
 
 initial clk = 0;
-always #5 clk = ~clk;
+always #2 clk = ~clk;
 
 initial begin
-    clear <= 1;
+    clear = 1;
 
-    #5 clear <= 0;
+    #5 clear = 0;
 
-    #200 clear <= 1;
+    #50 clear = 1;
+    #50 clear = 0; // Caso demorado
 
-    #500 $finish;
+    #50 clear = 1;
+    #5 clear = 0; // Caso rápido
+
+    #50 clear = 1;
+    #5 clear = 0; // Caso rápido
+
+    #50 $finish;
 end
 
 initial begin


### PR DESCRIPTION
Troca o nome do fio "numped-pressed" para clear e muda o limiar da contagem de 3 para 4, pela especificação.